### PR TITLE
Add development support for reloading templates when you render them

### DIFF
--- a/Sources/Mustache/Context.swift
+++ b/Sources/Mustache/Context.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -20,15 +20,17 @@ struct MustacheContext {
     let inherited: [String: MustacheTemplate]?
     let contentType: MustacheContentType
     let library: MustacheLibrary?
+    let reloadPartials: Bool
 
     /// initialize context with a single objectt
-    init(_ object: Any, library: MustacheLibrary? = nil) {
+    init(_ object: Any, library: MustacheLibrary? = nil, reloadPartials: Bool = false) {
         self.stack = [object]
         self.sequenceContext = nil
         self.indentation = nil
         self.inherited = nil
         self.contentType = HTMLContentType()
         self.library = library
+        self.reloadPartials = reloadPartials
     }
 
     private init(
@@ -37,7 +39,8 @@ struct MustacheContext {
         indentation: String?,
         inherited: [String: MustacheTemplate]?,
         contentType: MustacheContentType,
-        library: MustacheLibrary? = nil
+        library: MustacheLibrary? = nil,
+        reloadPartials: Bool
     ) {
         self.stack = stack
         self.sequenceContext = sequenceContext
@@ -45,6 +48,7 @@ struct MustacheContext {
         self.inherited = inherited
         self.contentType = contentType
         self.library = library
+        self.reloadPartials = reloadPartials
     }
 
     /// return context with object add to stack
@@ -57,7 +61,8 @@ struct MustacheContext {
             indentation: self.indentation,
             inherited: self.inherited,
             contentType: self.contentType,
-            library: self.library
+            library: self.library,
+            reloadPartials: self.reloadPartials
         )
     }
 
@@ -83,7 +88,8 @@ struct MustacheContext {
             indentation: indentation,
             inherited: inherits,
             contentType: HTMLContentType(),
-            library: self.library
+            library: self.library,
+            reloadPartials: self.reloadPartials
         )
     }
 
@@ -114,7 +120,8 @@ struct MustacheContext {
             indentation: self.indentation,
             inherited: self.inherited,
             contentType: self.contentType,
-            library: self.library
+            library: self.library,
+            reloadPartials: self.reloadPartials
         )
     }
 
@@ -126,7 +133,8 @@ struct MustacheContext {
             indentation: self.indentation,
             inherited: self.inherited,
             contentType: contentType,
-            library: self.library
+            library: self.library,
+            reloadPartials: self.reloadPartials
         )
     }
 }

--- a/Sources/Mustache/Context.swift
+++ b/Sources/Mustache/Context.swift
@@ -106,7 +106,8 @@ struct MustacheContext {
             indentation: indentation,
             inherited: self.inherited,
             contentType: self.contentType,
-            library: self.library
+            library: self.library,
+            reloadPartials: self.reloadPartials
         )
     }
 

--- a/Sources/Mustache/Library+FileSystem.swift
+++ b/Sources/Mustache/Library+FileSystem.swift
@@ -31,7 +31,7 @@ extension MustacheLibrary {
                 guard let template = try MustacheTemplate(filename: directory + path) else { continue }
                 // drop ".mustache" from path to get name
                 let name = String(path.dropLast(extWithDot.count))
-            templates[name] = template
+                templates[name] = template
             } catch let error as MustacheTemplate.ParserError {
                 throw ParserError(filename: path, context: error.context, error: error.error)
             }

--- a/Sources/Mustache/Library+FileSystem.swift
+++ b/Sources/Mustache/Library+FileSystem.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -27,17 +27,14 @@ extension MustacheLibrary {
         var templates: [String: MustacheTemplate] = [:]
         for case let path as String in enumerator {
             guard path.hasSuffix(extWithDot) else { continue }
-            guard let data = fs.contents(atPath: directory + path) else { continue }
-            let string = String(decoding: data, as: Unicode.UTF8.self)
-            var template: MustacheTemplate
             do {
-                template = try MustacheTemplate(string: string)
+                guard let template = try MustacheTemplate(filename: directory + path) else { continue }
+                // drop ".mustache" from path to get name
+                let name = String(path.dropLast(extWithDot.count))
+            templates[name] = template
             } catch let error as MustacheTemplate.ParserError {
                 throw ParserError(filename: path, context: error.context, error: error.error)
             }
-            // drop ".mustache" from path to get name
-            let name = String(path.dropLast(extWithDot.count))
-            templates[name] = template
         }
         return templates
     }

--- a/Sources/Mustache/Library.swift
+++ b/Sources/Mustache/Library.swift
@@ -82,6 +82,7 @@ public struct MustacheLibrary: Sendable {
     /// - Parameters:
     ///   - object: Object to render
     ///   - name: Name of template
+    ///   - reload: Reload templates when rendering
     /// - Returns: Rendered text
     public func render(_ object: Any, withTemplate name: String, reload: Bool) -> String? {
         guard let template = templates[name] else { return nil }

--- a/Sources/Mustache/Library.swift
+++ b/Sources/Mustache/Library.swift
@@ -77,7 +77,7 @@ public struct MustacheLibrary: Sendable {
         guard let template = templates[name] else { return nil }
         return template.render(object, library: self)
     }
-
+    #if DEBUG
     /// Render object using templated with name
     /// - Parameters:
     ///   - object: Object to render
@@ -88,6 +88,7 @@ public struct MustacheLibrary: Sendable {
         guard let template = templates[name] else { return nil }
         return template.render(object, library: self, reload: reload)
     }
+    #endif
 
     /// Error returned by init() when parser fails
     public struct ParserError: Swift.Error {

--- a/Sources/Mustache/Library.swift
+++ b/Sources/Mustache/Library.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -76,6 +76,16 @@ public struct MustacheLibrary: Sendable {
     public func render(_ object: Any, withTemplate name: String) -> String? {
         guard let template = templates[name] else { return nil }
         return template.render(object, library: self)
+    }
+
+    /// Render object using templated with name
+    /// - Parameters:
+    ///   - object: Object to render
+    ///   - name: Name of template
+    /// - Returns: Rendered text
+    public func render(_ object: Any, withTemplate name: String, reload: Bool) -> String? {
+        guard let template = templates[name] else { return nil }
+        return template.render(object, library: self, reload: reload)
     }
 
     /// Error returned by init() when parser fails

--- a/Sources/Mustache/Library.swift
+++ b/Sources/Mustache/Library.swift
@@ -77,6 +77,7 @@ public struct MustacheLibrary: Sendable {
         guard let template = templates[name] else { return nil }
         return template.render(object, library: self)
     }
+
     #if DEBUG
     /// Render object using templated with name
     /// - Parameters:

--- a/Sources/Mustache/Library.swift
+++ b/Sources/Mustache/Library.swift
@@ -78,7 +78,6 @@ public struct MustacheLibrary: Sendable {
         return template.render(object, library: self)
     }
 
-    #if DEBUG
     /// Render object using templated with name
     /// - Parameters:
     ///   - object: Object to render
@@ -87,9 +86,12 @@ public struct MustacheLibrary: Sendable {
     /// - Returns: Rendered text
     public func render(_ object: Any, withTemplate name: String, reload: Bool) -> String? {
         guard let template = templates[name] else { return nil }
+        #if DEBUG
         return template.render(object, library: self, reload: reload)
+        #else
+        return template.render(object, library: self)
+        #endif
     }
-    #endif
 
     /// Error returned by init() when parser fails
     public struct ParserError: Swift.Error {

--- a/Sources/Mustache/Library.swift
+++ b/Sources/Mustache/Library.swift
@@ -82,7 +82,7 @@ public struct MustacheLibrary: Sendable {
     /// - Parameters:
     ///   - object: Object to render
     ///   - name: Name of template
-    ///   - reload: Reload templates when rendering
+    ///   - reload: Reload templates when rendering. This is only available in debug builds
     /// - Returns: Rendered text
     public func render(_ object: Any, withTemplate name: String, reload: Bool) -> String? {
         guard let template = templates[name] else { return nil }

--- a/Sources/Mustache/Template+FileSystem.swift
+++ b/Sources/Mustache/Template+FileSystem.swift
@@ -15,12 +15,12 @@
 import Foundation
 
 extension MustacheTemplate {
-    /// Initialize template
+    /// Internal function to load a template from a file
     /// - Parameters
     ///   - string: Template text
     ///   - filename: File template was loaded from
     /// - Throws: MustacheTemplate.Error
-    public init?(filename: String) throws {
+    init?(filename: String) throws {
         let fs = FileManager()
         guard let data = fs.contents(atPath: filename) else { return nil }
         let string = String(decoding: data, as: Unicode.UTF8.self)

--- a/Sources/Mustache/Template+FileSystem.swift
+++ b/Sources/Mustache/Template+FileSystem.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension MustacheTemplate {
+        /// Initialize template
+    /// - Parameters
+    ///   - string: Template text
+    ///   - filename: File template was loaded from
+    /// - Throws: MustacheTemplate.Error
+    public init?(filename: String) throws {
+        let fs = FileManager()
+        guard let data = fs.contents(atPath: filename) else { return nil }
+        let string = String(decoding: data, as: Unicode.UTF8.self)
+        self.tokens = try Self.parse(string)
+        self.filename = filename
+    }
+}

--- a/Sources/Mustache/Template+FileSystem.swift
+++ b/Sources/Mustache/Template+FileSystem.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 extension MustacheTemplate {
-        /// Initialize template
+    /// Initialize template
     /// - Parameters
     ///   - string: Template text
     ///   - filename: File template was loaded from

--- a/Sources/Mustache/Template+Render.swift
+++ b/Sources/Mustache/Template+Render.swift
@@ -85,6 +85,7 @@ extension MustacheTemplate {
 
         case .partial(let name, let indentation, let overrides):
             if var template = context.library?.getTemplate(named: name) {
+                #if DEBUG
                 if context.reloadPartials {
                     guard let filename = template.filename else {
                         preconditionFailure("Can only use reload if template was generated from a file")
@@ -96,6 +97,7 @@ extension MustacheTemplate {
                         return "\(error)"
                     }
                 }
+                #endif
                 return template.render(context: context.withPartial(indented: indentation, inheriting: overrides))
             }
 

--- a/Sources/Mustache/Template+Render.swift
+++ b/Sources/Mustache/Template+Render.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -84,7 +84,18 @@ extension MustacheTemplate {
             }
 
         case .partial(let name, let indentation, let overrides):
-            if let template = context.library?.getTemplate(named: name) {
+            if var template = context.library?.getTemplate(named: name) {
+                if context.reloadPartials {
+                    guard let filename = template.filename else {
+                        preconditionFailure("Can only use reload if template was generated from a file")
+                    }
+                    do {
+                        guard let partialTemplate = try MustacheTemplate(filename: filename) else { return "Cannot find template at \(filename)" }
+                        template = partialTemplate
+                    } catch {
+                        return "\(error)"
+                    }
+                }
                 return template.render(context: context.withPartial(indented: indentation, inheriting: overrides))
             }
 

--- a/Sources/Mustache/Template.swift
+++ b/Sources/Mustache/Template.swift
@@ -53,6 +53,7 @@ public struct MustacheTemplate: Sendable {
         #endif
         return self.render(context: .init(object, library: library))
     }
+
     internal init(_ tokens: [Token]) {
         self.tokens = tokens
         self.filename = nil

--- a/Sources/Mustache/Template.swift
+++ b/Sources/Mustache/Template.swift
@@ -35,10 +35,10 @@ public struct MustacheTemplate: Sendable {
     /// - Parameters
     ///   - object: Object to render
     ///   - library: library template uses to access partials
-    ///   - reload: Should I reload this template when rendering
+    ///   - reload: Should I reload this template when rendering. This is only available in debug builds
     /// - Returns: Rendered text
-    #if DEBUG
     public func render(_ object: Any, library: MustacheLibrary? = nil, reload: Bool) -> String {
+        #if DEBUG
         if reload {
             guard let filename else {
                 preconditionFailure("Can only use reload if template was generated from a file")
@@ -49,11 +49,10 @@ public struct MustacheTemplate: Sendable {
             } catch {
                 return "\(error)"
             }
-        } else {
-            return self.render(context: .init(object, library: library))
         }
+        #endif
+        return self.render(context: .init(object, library: library))
     }
-    #endif
     internal init(_ tokens: [Token]) {
         self.tokens = tokens
         self.filename = nil

--- a/Sources/Mustache/Template.swift
+++ b/Sources/Mustache/Template.swift
@@ -37,6 +37,7 @@ public struct MustacheTemplate: Sendable {
     ///   - library: library template uses to access partials
     ///   - reload: Should I reload this template when rendering
     /// - Returns: Rendered text
+    #if DEBUG
     public func render(_ object: Any, library: MustacheLibrary? = nil, reload: Bool) -> String {
         if reload {
             guard let filename else {
@@ -52,7 +53,7 @@ public struct MustacheTemplate: Sendable {
             return self.render(context: .init(object, library: library))
         }
     }
-
+    #endif
     internal init(_ tokens: [Token]) {
         self.tokens = tokens
         self.filename = nil

--- a/Sources/Mustache/Template.swift
+++ b/Sources/Mustache/Template.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2021 the Hummingbird authors
+// Copyright (c) 2021-2024 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -19,17 +19,43 @@ public struct MustacheTemplate: Sendable {
     /// - Throws: MustacheTemplate.Error
     public init(string: String) throws {
         self.tokens = try Self.parse(string)
+        self.filename = nil
     }
 
     /// Render object using this template
-    /// - Parameter object: Object to render
+    /// - Parameters
+    ///   - object: Object to render
+    ///   - library: library template uses to access partials
     /// - Returns: Rendered text
     public func render(_ object: Any, library: MustacheLibrary? = nil) -> String {
         self.render(context: .init(object, library: library))
     }
 
+    /// Render object using this template
+    /// - Parameters
+    ///   - object: Object to render
+    ///   - library: library template uses to access partials
+    ///   - reload: Should I reload this template when rendering
+    /// - Returns: Rendered text
+    public func render(_ object: Any, library: MustacheLibrary? = nil, reload: Bool) -> String {
+        if reload {
+            guard let filename else {
+                preconditionFailure("Can only use reload if template was generated from a file")
+            }
+            do {
+                guard let template = try MustacheTemplate(filename: filename) else { return "Cannot find template at \(filename)" }
+                return template.render(context: .init(object, library: library, reloadPartials: reload))
+            } catch {
+                return "\(error)"
+            }
+        } else {
+            return self.render(context: .init(object, library: library))
+        }
+    }
+
     internal init(_ tokens: [Token]) {
         self.tokens = tokens
+        self.filename = nil
     }
 
     enum Token: Sendable {
@@ -45,4 +71,5 @@ public struct MustacheTemplate: Sendable {
     }
 
     var tokens: [Token]
+    let filename: String?
 }

--- a/Tests/MustacheTests/LibraryTests.swift
+++ b/Tests/MustacheTests/LibraryTests.swift
@@ -71,6 +71,7 @@ final class LibraryTests: XCTestCase {
             XCTAssertEqual(parserError.context.columnNumber, 10)
         }
     }
+
     #if DEBUG
     func testReload() async throws {
         let fs = FileManager()

--- a/Tests/MustacheTests/LibraryTests.swift
+++ b/Tests/MustacheTests/LibraryTests.swift
@@ -71,7 +71,7 @@ final class LibraryTests: XCTestCase {
             XCTAssertEqual(parserError.context.columnNumber, 10)
         }
     }
-
+    #if DEBUG
     func testReload() async throws {
         let fs = FileManager()
         try? fs.createDirectory(atPath: "templates", withIntermediateDirectories: false)
@@ -108,4 +108,5 @@ final class LibraryTests: XCTestCase {
         try mustache3.write(to: URL(fileURLWithPath: "templates/test-partial.mustache"))
         XCTAssertEqual(library.render(object, withTemplate: "test", reload: true), "<test2><value>value1</value><value>value2</value></test2>")
     }
+    #endif
 }


### PR DESCRIPTION
This is to speed up development using swift-mustache. 
Added version of render functions that include a`reload` parameter that will reload the template. This allows users to edit templates without requiring them to restart the server.