### PR TITLE
Fix issues from Inheritance spec

### DIFF
--- a/Sources/Mustache/Context.swift
+++ b/Sources/Mustache/Context.swift
@@ -87,6 +87,23 @@ struct MustacheContext {
         )
     }
 
+    /// return context with indent information for invoking an inheritance block
+    func withInheritanceBlock(indented: String?) -> MustacheContext {
+        let indentation: String? = if let indented {
+            (self.indentation ?? "") + indented
+        } else {
+            self.indentation
+        }
+        return .init(
+            stack: self.stack,
+            sequenceContext: nil,
+            indentation: indentation,
+            inherited: self.inherited,
+            contentType: self.contentType,
+            library: self.library
+        )
+    }
+
     /// return context with sequence info and sequence element added to stack
     func withSequence(_ object: Any, sequenceContext: MustacheSequenceContext) -> MustacheContext {
         var stack = self.stack

--- a/Sources/Mustache/Context.swift
+++ b/Sources/Mustache/Context.swift
@@ -88,7 +88,7 @@ struct MustacheContext {
     }
 
     /// return context with indent information for invoking an inheritance block
-    func withInheritanceBlock(indented: String?) -> MustacheContext {
+    func withBlockExpansion(indented: String?) -> MustacheContext {
         let indentation: String? = if let indented {
             (self.indentation ?? "") + indented
         } else {

--- a/Sources/Mustache/Template+Parser.swift
+++ b/Sources/Mustache/Template+Parser.swift
@@ -223,6 +223,9 @@ extension MustacheTemplate {
                 // partial
                 parser.unsafeAdvance()
                 let name = try parsePartialName(&parser, state: state)
+                if whiteSpaceBefore.count > 0 {
+                    tokens.append(.text(String(whiteSpaceBefore)))
+                }
                 if self.isStandalone(&parser, state: state) {
                     setNewLine = true
                     tokens.append(.partial(name, indentation: String(whiteSpaceBefore), inherits: nil))
@@ -235,6 +238,9 @@ extension MustacheTemplate {
                 // partial with inheritance
                 parser.unsafeAdvance()
                 let name = try parsePartialName(&parser, state: state)
+                if whiteSpaceBefore.count > 0 {
+                    tokens.append(.text(String(whiteSpaceBefore)))
+                }
                 if self.isStandalone(&parser, state: state) {
                     setNewLine = true
                 }
@@ -269,6 +275,9 @@ extension MustacheTemplate {
                     tokens.append(.blockDefinition(name: name, template: MustacheTemplate(sectionTokens)))
 
                 } else {
+                    if whiteSpaceBefore.count > 0 {
+                        tokens.append(.text(String(whiteSpaceBefore)))
+                    }
                     if self.isStandalone(&parser, state: state) {
                         setNewLine = true
                     } else if whiteSpaceBefore.count > 0 {}

--- a/Sources/Mustache/Template+Parser.swift
+++ b/Sources/Mustache/Template+Parser.swift
@@ -59,6 +59,7 @@ extension MustacheTemplate {
         var flags: Flags
         var startDelimiter: String
         var endDelimiter: String
+        var partialDefinitionIndent: Substring?
 
         var newLine: Bool {
             get { self.flags.contains(.newLine) }
@@ -124,7 +125,16 @@ extension MustacheTemplate {
             // if new line read whitespace
             if state.newLine {
                 let whiteSpace = parser.read(while: Set(" \t"))
-                if !state.flags.contains(.isPartialDefinition) {
+                // If inside a partial block definition
+                if state.flags.contains(.isPartialDefinition), !state.flags.contains(.isPartialDefinitionTopLevel) {
+                    // if definition indent has been set then remove it from current whitespace otherwise set the
+                    // indent as this is the first line of the partial definition
+                    if let partialDefinitionIndent = state.partialDefinitionIndent {
+                        whiteSpaceBefore = whiteSpace.dropFirst(partialDefinitionIndent.count)
+                    } else {
+                        state.partialDefinitionIndent = whiteSpace
+                    }
+                } else {
                     whiteSpaceBefore = whiteSpace
                 }
             }

--- a/Sources/Mustache/Template+Render.swift
+++ b/Sources/Mustache/Template+Render.swift
@@ -78,9 +78,9 @@ extension MustacheTemplate {
 
         case .blockExpansion(let name, let defaultTemplate, let indented):
             if let override = context.inherited?[name] {
-                return override.render(context: context.withInheritanceBlock(indented: indented))
+                return override.render(context: context.withBlockExpansion(indented: indented))
             } else {
-                return defaultTemplate.render(context: context.withInheritanceBlock(indented: indented))
+                return defaultTemplate.render(context: context.withBlockExpansion(indented: indented))
             }
 
         case .partial(let name, let indentation, let overrides):

--- a/Sources/Mustache/Template+Render.swift
+++ b/Sources/Mustache/Template+Render.swift
@@ -28,7 +28,8 @@ extension MustacheTemplate {
         if let indentation = context.indentation, indentation != "" {
             for token in tokens {
                 let renderedString = self.renderToken(token, context: &context)
-                if renderedString != "", string.last == "\n" {
+                // if rendered string is not empty and we are on a new line
+                if renderedString.count > 0, string.last == "\n" || string.count == 0 {
                     string += indentation
                 }
                 string += renderedString
@@ -75,11 +76,11 @@ extension MustacheTemplate {
             let child = self.getChild(named: variable, transforms: transforms, context: context)
             return self.renderInvertedSection(child, with: template, context: context)
 
-        case .inheritedSection(let name, let template):
+        case .blockExpansion(let name, let defaultTemplate, let indented):
             if let override = context.inherited?[name] {
-                return override.render(context: context)
+                return override.render(context: context.withInheritanceBlock(indented: indented))
             } else {
-                return template.render(context: context)
+                return defaultTemplate.render(context: context.withInheritanceBlock(indented: indented))
             }
 
         case .partial(let name, let indentation, let overrides):
@@ -89,6 +90,9 @@ extension MustacheTemplate {
 
         case .contentType(let contentType):
             context = context.withContentType(contentType)
+
+        case .blockDefinition:
+            fatalError("Should not be rendering block definitions")
         }
         return ""
     }

--- a/Sources/Mustache/Template+Render.swift
+++ b/Sources/Mustache/Template+Render.swift
@@ -29,7 +29,7 @@ extension MustacheTemplate {
             for token in tokens {
                 let renderedString = self.renderToken(token, context: &context)
                 // if rendered string is not empty and we are on a new line
-                if renderedString.count > 0, string.last == "\n" || string.count == 0 {
+                if renderedString.count > 0, string.last == "\n" {
                     string += indentation
                 }
                 string += renderedString

--- a/Sources/Mustache/Template.swift
+++ b/Sources/Mustache/Template.swift
@@ -38,7 +38,8 @@ public struct MustacheTemplate: Sendable {
         case unescapedVariable(name: String, transforms: [String] = [])
         case section(name: String, transforms: [String] = [], template: MustacheTemplate)
         case invertedSection(name: String, transforms: [String] = [], template: MustacheTemplate)
-        case inheritedSection(name: String, template: MustacheTemplate)
+        case blockDefinition(name: String, template: MustacheTemplate)
+        case blockExpansion(name: String, default: MustacheTemplate, indentation: String?)
         case partial(String, indentation: String?, inherits: [String: MustacheTemplate]?)
         case contentType(MustacheContentType)
     }

--- a/Tests/MustacheTests/PartialTests.swift
+++ b/Tests/MustacheTests/PartialTests.swift
@@ -62,8 +62,7 @@ final class PartialTests: XCTestCase {
         """)
         var library = MustacheLibrary()
         library.register(template, named: "base")
-        library.register(template2, named: "user") // , withTemplate: String)// = MustacheLibrary(templates: ["base": template, "user": template2])
-
+        library.register(template2, named: "user")
         let object: [String: Any] = ["names": ["john", "adam", "claire"]]
         XCTAssertEqual(library.render(object, withTemplate: "base"), """
         <h2>Names</h2>

--- a/Tests/MustacheTests/PartialTests.swift
+++ b/Tests/MustacheTests/PartialTests.swift
@@ -21,7 +21,7 @@ final class PartialTests: XCTestCase {
         let template = try MustacheTemplate(string: """
         <h2>Names</h2>
         {{#names}}
-          {{> user}}
+            {{> user}}
         {{/names}}
         """)
         let template2 = try MustacheTemplate(string: """
@@ -33,9 +33,9 @@ final class PartialTests: XCTestCase {
         let object: [String: Any] = ["names": ["john", "adam", "claire"]]
         XCTAssertEqual(library.render(object, withTemplate: "base"), """
         <h2>Names</h2>
-          <strong>john</strong>
-          <strong>adam</strong>
-          <strong>claire</strong>
+            <strong>john</strong>
+            <strong>adam</strong>
+            <strong>claire</strong>
 
         """)
     }
@@ -106,7 +106,6 @@ final class PartialTests: XCTestCase {
             <head>
             <title>{{$title}}Default title{{/title}}</title>
             </head>
-
             """,
             named: "header"
         )

--- a/Tests/MustacheTests/PartialTests.swift
+++ b/Tests/MustacheTests/PartialTests.swift
@@ -173,4 +173,32 @@ final class PartialTests: XCTestCase {
 
         """)
     }
+
+    func testInheritanceIndentation() throws {
+        var library = MustacheLibrary()
+        try library.register(
+            """
+            Hi,
+               {{$block}}{{/block}}
+            """,
+            named: "parent"
+        )
+        try library.register(
+            """
+            {{<parent}}
+            {{$block}}
+              one
+               two
+            {{/block}}
+            {{/parent}}
+            """,
+            named: "template"
+        )
+        XCTAssertEqual(library.render({}, withTemplate: "template"), """
+        Hi,
+           one
+            two
+
+        """)
+    }
 }

--- a/Tests/MustacheTests/PartialTests.swift
+++ b/Tests/MustacheTests/PartialTests.swift
@@ -75,6 +75,37 @@ final class PartialTests: XCTestCase {
         """)
     }
 
+    func testTrailingNewLines() throws {
+        let template1 = try MustacheTemplate(string: """
+        {{> withNewLine }}
+        >> {{> withNewLine }}
+        [ {{> withNewLine }} ]
+        """)
+        let template2 = try MustacheTemplate(string: """
+        {{> withoutNewLine }}
+        >> {{> withoutNewLine }}
+        [ {{> withoutNewLine }} ]
+        """)
+        let withNewLine = try MustacheTemplate(string: """
+        {{#things}}{{.}}, {{/things}}
+
+        """)
+        let withoutNewLine = try MustacheTemplate(string: "{{#things}}{{.}}, {{/things}}")
+        let library = MustacheLibrary(templates: ["base1": template1, "base2": template2, "withNewLine": withNewLine, "withoutNewLine": withoutNewLine])
+        let object = ["things": [1, 2, 3, 4, 5]]
+        XCTAssertEqual(library.render(object, withTemplate: "base1"), """
+        1, 2, 3, 4, 5, 
+        >> 1, 2, 3, 4, 5, 
+
+        [ 1, 2, 3, 4, 5, 
+         ]
+        """)
+        XCTAssertEqual(library.render(object, withTemplate: "base2"), """
+        1, 2, 3, 4, 5, >> 1, 2, 3, 4, 5, 
+        [ 1, 2, 3, 4, 5,  ]
+        """)
+    }
+
     /// Testing dynamic partials
     func testDynamicPartials() throws {
         let template = try MustacheTemplate(string: """

--- a/Tests/MustacheTests/SpecTests.swift
+++ b/Tests/MustacheTests/SpecTests.swift
@@ -86,7 +86,19 @@ final class MustacheSpecTests: XCTestCase {
 
             func XCTAssertSpecEqual(_ result: String?, _ test: Spec.Test) {
                 if result != test.expected {
-                    XCTFail("\n\(test.desc)result:\n\(result ?? "nil")\nexpected:\n\(test.expected)")
+                    XCTFail("""
+                    \(test.name)
+                    \(test.desc)
+                    template:
+                    \(test.template)
+                    data:
+                    \(test.data.value)
+                    \(test.partials.map { "partials:\n\($0)" } ?? "")
+                    result:
+                    \(result ?? "nil")
+                    expected:
+                    \(test.expected)
+                    """)
                 }
             }
         }
@@ -108,6 +120,24 @@ final class MustacheSpecTests: XCTestCase {
         let date = Date()
         for test in spec.tests {
             guard !ignoring.contains(test.name) else { continue }
+            XCTAssertNoThrow(try test.run())
+        }
+        print(-date.timeIntervalSinceNow)
+    }
+
+    func testSpec(name: String, only: [String]) throws {
+        let url = URL(string: "https://raw.githubusercontent.com/mustache/spec/master/specs/\(name).json")!
+        try testSpec(url: url, only: only)
+    }
+
+    func testSpec(url: URL, only: [String]) throws {
+        let data = try Data(contentsOf: url)
+        let spec = try JSONDecoder().decode(Spec.self, from: data)
+
+        print(spec.overview)
+        let date = Date()
+        for test in spec.tests {
+            guard only.contains(test.name) else { continue }
             XCTAssertNoThrow(try test.run())
         }
         print(-date.timeIntervalSinceNow)
@@ -138,7 +168,14 @@ final class MustacheSpecTests: XCTestCase {
     }
 
     func testInheritanceSpec() throws {
-        try XCTSkipIf(true) // inheritance spec has been updated and has added requirements, we don't yet support
-        try self.testSpec(name: "~inheritance")
+        try self.testSpec(
+            name: "~inheritance",
+            ignoring: [
+                "Standalone block",
+                "Block reindentation",
+                "Intrinsic indentation",
+                // "Nested block reindentation",
+            ]
+        )
     }
 }

--- a/Tests/MustacheTests/SpecTests.swift
+++ b/Tests/MustacheTests/SpecTests.swift
@@ -166,7 +166,6 @@ final class MustacheSpecTests: XCTestCase {
     }
 
     func testInheritanceSpec() throws {
-        // try self.testSpec(name: "~inheritance", only: ["Nested block reindentation"])
         try self.testSpec(
             name: "~inheritance",
             ignoring: [

--- a/Tests/MustacheTests/SpecTests.swift
+++ b/Tests/MustacheTests/SpecTests.swift
@@ -116,7 +116,6 @@ final class MustacheSpecTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let spec = try JSONDecoder().decode(Spec.self, from: data)
 
-        print(spec.overview)
         let date = Date()
         for test in spec.tests {
             guard !ignoring.contains(test.name) else { continue }
@@ -134,7 +133,6 @@ final class MustacheSpecTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let spec = try JSONDecoder().decode(Spec.self, from: data)
 
-        print(spec.overview)
         let date = Date()
         for test in spec.tests {
             guard only.contains(test.name) else { continue }
@@ -156,7 +154,7 @@ final class MustacheSpecTests: XCTestCase {
     }
 
     func testInvertedSpec() throws {
-        try self.testSpec(name: "inverted")
+        try self.testSpec(name: "inverted", only: ["Standalone Line Endings"])
     }
 
     func testPartialsSpec() throws {
@@ -164,17 +162,16 @@ final class MustacheSpecTests: XCTestCase {
     }
 
     func testSectionsSpec() throws {
-        try self.testSpec(name: "sections")
+        try self.testSpec(name: "sections", only: ["Standalone Line Endings"])
     }
 
     func testInheritanceSpec() throws {
+        // try self.testSpec(name: "~inheritance", only: ["Nested block reindentation"])
         try self.testSpec(
             name: "~inheritance",
             ignoring: [
-                "Standalone block",
-                "Block reindentation",
                 "Intrinsic indentation",
-                // "Nested block reindentation",
+                "Nested block reindentation",
             ]
         )
     }

--- a/Tests/MustacheTests/SpecTests.swift
+++ b/Tests/MustacheTests/SpecTests.swift
@@ -154,7 +154,7 @@ final class MustacheSpecTests: XCTestCase {
     }
 
     func testInvertedSpec() throws {
-        try self.testSpec(name: "inverted", only: ["Standalone Line Endings"])
+        try self.testSpec(name: "inverted")
     }
 
     func testPartialsSpec() throws {
@@ -162,7 +162,7 @@ final class MustacheSpecTests: XCTestCase {
     }
 
     func testSectionsSpec() throws {
-        try self.testSpec(name: "sections", only: ["Standalone Line Endings"])
+        try self.testSpec(name: "sections")
     }
 
     func testInheritanceSpec() throws {


### PR DESCRIPTION
This PR fixes a number of issues related to the inheritance spec (minus two tests)
- I've split the inheritance block token into two types, block definition and block expansion.
- Added indentation to block expansion
- Added flags to parser state to indicate whether we are in a partial definition or not 
- Remove indentation from partial definitions
- Add support for testing only one test from spec file