### PR TITLE
Make `MustacheSequence` public

### DIFF
--- a/Sources/Mustache/Context.swift
+++ b/Sources/Mustache/Context.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Context while rendering mustache tokens
-public struct MustacheContext {
+struct MustacheContext {
     let stack: [Any]
     let sequenceContext: MustacheSequenceContext?
     let indentation: String?

--- a/Sources/Mustache/Context.swift
+++ b/Sources/Mustache/Context.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Context while rendering mustache tokens
-struct MustacheContext {
+public struct MustacheContext {
     let stack: [Any]
     let sequenceContext: MustacheSequenceContext?
     let indentation: String?

--- a/Sources/Mustache/Sequence.swift
+++ b/Sources/Mustache/Sequence.swift
@@ -13,7 +13,22 @@
 //===----------------------------------------------------------------------===//
 
 /// Protocol for objects that can be rendered as a sequence in Mustache
-protocol MustacheSequence {
+///
+/// You're not supposed to manually conform to this protocol.
+/// Instead, conform your type to `Sequence`, and then declare conformance to `MustacheSequence` too.
+/// This way you'll get the automatically-synthesized conformance of `Sequence` to `MustacheSequence`.
+///
+/// ```swift
+/// import Mustache
+///
+/// struct MyCustomMustacheSequence: Sequence {
+/// /// Provide necessary declarations so the type conforms to `Sequence`
+/// }
+///
+/// /// Receive the automatically-synthesized conformance to `MustacheSequence` for free.
+/// extension MyCustomMustacheSequence: MustacheSequence {}
+/// ```
+public protocol MustacheSequence {
     /// Render section using template
     func renderSection(with template: MustacheTemplate, context: MustacheContext) -> String
     /// Render inverted section using template
@@ -22,7 +37,7 @@ protocol MustacheSequence {
 
 extension Sequence {
     /// Render section using template
-    func renderSection(with template: MustacheTemplate, context: MustacheContext) -> String {
+    public func renderSection(with template: MustacheTemplate, context: MustacheContext) -> String {
         var string = ""
         var sequenceContext = MustacheSequenceContext(first: true)
 
@@ -43,7 +58,7 @@ extension Sequence {
     }
 
     /// Render inverted section using template
-    func renderInvertedSection(with template: MustacheTemplate, context: MustacheContext) -> String {
+    public func renderInvertedSection(with template: MustacheTemplate, context: MustacheContext) -> String {
         var iterator = makeIterator()
         if iterator.next() == nil {
             return template.render(context: context.withObject(self))

--- a/Sources/Mustache/Sequence.swift
+++ b/Sources/Mustache/Sequence.swift
@@ -13,31 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 /// Protocol for objects that can be rendered as a sequence in Mustache
-///
-/// You're not supposed to manually conform to this protocol.
-/// Instead, conform your type to `Sequence`, and then declare conformance to `MustacheSequence` too.
-/// This way you'll get the automatically-synthesized conformance of `Sequence` to `MustacheSequence`.
-///
-/// ```swift
-/// import Mustache
-///
-/// struct MyCustomMustacheSequence: Sequence {
-/// /// Provide necessary declarations so the type conforms to `Sequence`
-/// }
-///
-/// /// Receive the automatically-synthesized conformance to `MustacheSequence` for free.
-/// extension MyCustomMustacheSequence: MustacheSequence {}
-/// ```
-public protocol MustacheSequence: Sequence {
-    /// Render section using template
-    func renderSection(with template: MustacheTemplate, context: MustacheContext) -> String
-    /// Render inverted section using template
-    func renderInvertedSection(with template: MustacheTemplate, context: MustacheContext) -> String
-}
+public protocol MustacheSequence: Sequence {}
 
 extension MustacheSequence {
     /// Render section using template
-    public func renderSection(with template: MustacheTemplate, context: MustacheContext) -> String {
+    func renderSection(with template: MustacheTemplate, context: MustacheContext) -> String {
         var string = ""
         var sequenceContext = MustacheSequenceContext(first: true)
 
@@ -58,7 +38,7 @@ extension MustacheSequence {
     }
 
     /// Render inverted section using template
-    public func renderInvertedSection(with template: MustacheTemplate, context: MustacheContext) -> String {
+    func renderInvertedSection(with template: MustacheTemplate, context: MustacheContext) -> String {
         var iterator = makeIterator()
         if iterator.next() == nil {
             return template.render(context: context.withObject(self))

--- a/Sources/Mustache/Sequence.swift
+++ b/Sources/Mustache/Sequence.swift
@@ -28,14 +28,14 @@
 /// /// Receive the automatically-synthesized conformance to `MustacheSequence` for free.
 /// extension MyCustomMustacheSequence: MustacheSequence {}
 /// ```
-public protocol MustacheSequence {
+public protocol MustacheSequence: Sequence {
     /// Render section using template
     func renderSection(with template: MustacheTemplate, context: MustacheContext) -> String
     /// Render inverted section using template
     func renderInvertedSection(with template: MustacheTemplate, context: MustacheContext) -> String
 }
 
-extension Sequence {
+extension MustacheSequence {
     /// Render section using template
     public func renderSection(with template: MustacheTemplate, context: MustacheContext) -> String {
         var string = ""

--- a/Sources/Mustache/Template+Render.swift
+++ b/Sources/Mustache/Template+Render.swift
@@ -98,7 +98,7 @@ extension MustacheTemplate {
     /// - Returns: Rendered text
     func renderSection(_ child: Any?, with template: MustacheTemplate, context: MustacheContext) -> String {
         switch child {
-        case let array as MustacheSequence:
+        case let array as any MustacheSequence:
             return array.renderSection(with: template, context: context)
         case let bool as Bool:
             return bool ? template.render(context: context) : ""
@@ -121,7 +121,7 @@ extension MustacheTemplate {
     /// - Returns: Rendered text
     func renderInvertedSection(_ child: Any?, with template: MustacheTemplate, context: MustacheContext) -> String {
         switch child {
-        case let array as MustacheSequence:
+        case let array as any MustacheSequence:
             return array.renderInvertedSection(with: template, context: context)
         case let bool as Bool:
             return bool ? "" : template.render(context: context)


### PR DESCRIPTION
Usecase is: https://github.com/MahdiBM/enumerator-macro/blob/981bbf25d4effe1cd73b8e2e953184d5835eed1e/Sources/EnumeratorMacroImpl/Types/EParameters.swift#L11

Basically to be able to provide custom transforms for a sequence type.
See `EParameters` (== `[Parameter]`) in the README: https://github.com/MahdiBM/enumerator-macro?tab=readme-ov-file#available-functions.

~~I've intentionally haven't made any properties of `MustacheSequence` public. I don't need those.~~