### PR TITLE
Add support for proper lambdas

### DIFF
--- a/Sources/Mustache/Lambda.swift
+++ b/Sources/Mustache/Lambda.swift
@@ -34,7 +34,7 @@
 ///
 public struct MustacheLambda {
     /// lambda callback
-    public typealias Callback = (Any, MustacheTemplate) -> String
+    public typealias Callback = (String) -> Any?
 
     let callback: Callback
 
@@ -44,7 +44,13 @@ public struct MustacheLambda {
         self.callback = cb
     }
 
-    internal func run(_ object: Any, _ template: MustacheTemplate) -> String {
-        return self.callback(object, template)
+    /// Initialize `MustacheLambda`
+    /// - Parameter cb: function to be called by lambda
+    public init(_ cb: @escaping () -> Any?) {
+        self.callback = { _ in cb() }
+    }
+
+    internal func callAsFunction(_ s: String) -> Any? {
+        return self.callback(s)
     }
 }

--- a/Sources/Mustache/Parser.swift
+++ b/Sources/Mustache/Parser.swift
@@ -100,6 +100,15 @@ extension Parser {
         return subString
     }
 
+    /// Read until we hit string index
+    /// - Parameter until: Read until position
+    /// - Returns: The string read from the buffer
+    mutating func read(until: String.Index) -> Substring {
+        let string = self.buffer[self.position..<until]
+        self.position = until
+        return string
+    }
+
     /// Read from buffer until we hit a character. Position after this is of the character we were checking for
     /// - Parameter until: Character to read until
     /// - Throws: .overflow if we hit the end of the buffer before reading character

--- a/Sources/Mustache/Template+FileSystem.swift
+++ b/Sources/Mustache/Template+FileSystem.swift
@@ -24,7 +24,9 @@ extension MustacheTemplate {
         let fs = FileManager()
         guard let data = fs.contents(atPath: filename) else { return nil }
         let string = String(decoding: data, as: Unicode.UTF8.self)
-        self.tokens = try Self.parse(string)
+        let template = try Self.parse(string)
+        self.tokens = template.tokens
+        self.text = string
         self.filename = filename
     }
 }

--- a/Sources/Mustache/Template.swift
+++ b/Sources/Mustache/Template.swift
@@ -13,12 +13,14 @@
 //===----------------------------------------------------------------------===//
 
 /// Class holding Mustache template
-public struct MustacheTemplate: Sendable {
+public struct MustacheTemplate: Sendable, CustomStringConvertible {
     /// Initialize template
     /// - Parameter string: Template text
     /// - Throws: MustacheTemplate.Error
     public init(string: String) throws {
-        self.tokens = try Self.parse(string)
+        let template = try Self.parse(string)
+        self.tokens = template.tokens
+        self.text = string
         self.filename = nil
     }
 
@@ -54,12 +56,15 @@ public struct MustacheTemplate: Sendable {
         return self.render(context: .init(object, library: library))
     }
 
-    internal init(_ tokens: [Token]) {
+    internal init(_ tokens: [Token], text: String) {
         self.tokens = tokens
         self.filename = nil
+        self.text = text
     }
 
-    enum Token: Sendable {
+    public var description: String { self.text }
+
+    enum Token: Sendable /* , CustomStringConvertible */ {
         case text(String)
         case variable(name: String, transforms: [String] = [])
         case unescapedVariable(name: String, transforms: [String] = [])
@@ -73,5 +78,6 @@ public struct MustacheTemplate: Sendable {
     }
 
     var tokens: [Token]
+    let text: String
     let filename: String?
 }

--- a/Tests/MustacheTests/TemplateParserTests.swift
+++ b/Tests/MustacheTests/TemplateParserTests.swift
@@ -28,12 +28,12 @@ final class TemplateParserTests: XCTestCase {
 
     func testSection() throws {
         let template = try MustacheTemplate(string: "test {{#section}}text{{/section}}")
-        XCTAssertEqual(template.tokens, [.text("test "), .section(name: "section", template: .init([.text("text")]))])
+        XCTAssertEqual(template.tokens, [.text("test "), .section(name: "section", template: .init([.text("text")], text: "text"))])
     }
 
     func testInvertedSection() throws {
         let template = try MustacheTemplate(string: "test {{^section}}text{{/section}}")
-        XCTAssertEqual(template.tokens, [.text("test "), .invertedSection(name: "section", template: .init([.text("text")]))])
+        XCTAssertEqual(template.tokens, [.text("test "), .invertedSection(name: "section", template: .init([.text("text")], text: "text"))])
     }
 
     func testComment() throws {


### PR DESCRIPTION
## Variable lambda
```swift
let a = (
    this: "This",
    that: "That",
    random: MustacheLambda { Bool.random() ? "{{this}}" : "{{that}}" }
)
let template = try MustacheTemplate(string: "{{random}}")
let output = template.render(a)
print(output)
```

Results in either
```
This
```
or
```
That
```

## Section lambda
```swift
let a = [
     "bold": MustachLambda { text in "<b>\(text)</b>" }
]
let template = try MustacheTemplate(string: "{{#bold}}text to render{{/bold}}")
let output = template.render(a)
print(output)
```
Results in
```
<b>text to render</b>
```